### PR TITLE
Fix admin login password toggle and reCAPTCHA message

### DIFF
--- a/public/backend/assets/js/script.js
+++ b/public/backend/assets/js/script.js
@@ -56,17 +56,19 @@
     $('.show-hide span').addClass('show');
 
     $('.show-hide span').on('click', function () {
-        if ($(this).hasClass('show')) {
-            $('input[name="login[password]"]').attr('type', 'text');
-            $(this).removeClass('show');
+        var $this = $(this);
+        var input = $this.parent().find('input');
+        if ($this.hasClass('show')) {
+            input.attr('type', 'text');
+            $this.removeClass('show');
         } else {
-            $('input[name="login[password]"]').attr('type', 'password');
-            $(this).addClass('show');
+            input.attr('type', 'password');
+            $this.addClass('show');
         }
     });
     $('form button[type="submit"]').on('click', function () {
         $('.show-hide span').addClass('show');
-        $('.show-hide').parent().find('input[name="login[password]"]').attr('type', 'password');
+        $('.show-hide').parent().find('input').attr('type', 'password');
     });
 
     /*=====================

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -44,6 +44,9 @@
                   </div>
                   <div class="form-group mb-3">
                     <div class="g-recaptcha" data-sitekey="{{ config('services.recaptcha.site_key') }}"></div>
+                    @error('g-recaptcha-response')
+                      <span class="text-danger">{{ $message }}</span>
+                    @enderror
                   </div>
                   <div class="form-group mb-0">
                     <div class="checkbox p-0">


### PR DESCRIPTION
## Summary
- fix admin login password toggle to target correct input
- show reCAPTCHA validation errors on admin login form

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_68b06f64349c832d800cf7d9d8d5b450