### PR TITLE
Allow admin login without reCAPTCHA and fix password toggle

### DIFF
--- a/app/Http/Controllers/Auth/AdminAuthController.php
+++ b/app/Http/Controllers/Auth/AdminAuthController.php
@@ -22,16 +22,20 @@ class AdminAuthController extends Controller
         $request->validate([
             'email' => 'required|email',
             'password' => 'required',
-            'g-recaptcha-response' => 'required',
+            'g-recaptcha-response' => 'nullable',
         ]);
 
-        if (! $this->validateRecaptcha($request->input('g-recaptcha-response'))) {
-            return back()->withErrors(['g-recaptcha-response' => 'Captcha verification failed']);
+        if ($request->filled('g-recaptcha-response') &&
+            ! $this->validateRecaptcha($request->input('g-recaptcha-response'))) {
+            return back()->withErrors([
+                'g-recaptcha-response' => 'Captcha verification failed',
+            ]);
         }
 
         $credentials = $request->only('email', 'password');
         if (Auth::guard('admin')->attempt($credentials, $request->boolean('remember'))) {
             $request->session()->regenerate();
+
             return redirect()->intended(route('admin.dashboard'));
         }
 
@@ -43,6 +47,7 @@ class AdminAuthController extends Controller
         Auth::guard('admin')->logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();
+
         return redirect()->route('admin.login');
     }
 

--- a/public/backend/assets/js/script.js
+++ b/public/backend/assets/js/script.js
@@ -57,7 +57,7 @@
 
     $('.show-hide span').on('click', function () {
         var $this = $(this);
-        var input = $this.parent().find('input');
+        var input = $this.closest('.form-input').find('input');
         if ($this.hasClass('show')) {
             input.attr('type', 'text');
             $this.removeClass('show');
@@ -68,7 +68,7 @@
     });
     $('form button[type="submit"]').on('click', function () {
         $('.show-hide span').addClass('show');
-        $('.show-hide').parent().find('input').attr('type', 'password');
+        $('.show-hide').closest('.form-input').find('input').attr('type', 'password');
     });
 
     /*=====================


### PR DESCRIPTION
## Summary
- Make admin login's reCAPTCHA field optional and only validate when provided
- Correct show/hide password button by locating the proper input element

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68b071888d68832d810639cd2acf0add