### PR TITLE
Style auth pages with user layout theme

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,18 +1,30 @@
-@extends('layouts.master')
+@extends('user.master')
 
-@section('user-content')
-<div class="auth-form">
-    <h2>Forgot Password</h2>
-    <form method="POST" action="{{ route('password.email') }}">
-        @csrf
-        <div>
-            <label for="email">Email Address</label>
-            <input type="email" name="email" id="email" value="{{ old('email') }}" required>
+@section('title', 'Forgot Password')
+
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header text-center">Forgot Password</div>
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('password.email') }}">
+                            @csrf
+                            <div class="mb-3">
+                                <label for="email" class="form-label">Email Address</label>
+                                <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Send Reset Link</button>
+                        </form>
+                        <div class="text-center mt-3">
+                            <a href="{{ route('login') }}">Back to Login</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <button type="submit">Send Reset Link</button>
-    </form>
-    <div class="links">
-        <a href="{{ route('login') }}">Back to Login</a>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,26 +1,39 @@
-@extends('layouts.master')
+@extends('user.master')
 
-@section('user-content')
-<div class="auth-form">
-    <h2>Login</h2>
-    <form method="POST" action="{{ route('login') }}">
-        @csrf
-        <div>
-            <label for="login">Username / Email / Phone</label>
-            <input type="text" name="login" id="login" value="{{ old('login') }}" required>
+@section('title', 'Login')
+
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header text-center">Login</div>
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('login') }}">
+                            @csrf
+                            <div class="mb-3">
+                                <label for="login" class="form-label">Username / Email / Phone</label>
+                                <input type="text" name="login" id="login" class="form-control" value="{{ old('login') }}" required autofocus>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label">Password</label>
+                                <input type="password" name="password" id="password" class="form-control" required>
+                            </div>
+                            <div class="mb-3 form-check">
+                                <input type="checkbox" name="remember" class="form-check-input" id="remember">
+                                <label class="form-check-label" for="remember">Remember Me</label>
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Login</button>
+                        </form>
+                        <div class="text-center mt-3">
+                            <a href="{{ route('password.request') }}" class="d-block">Forgot Password?</a>
+                            <a href="{{ route('register') }}" class="d-block">Register</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div>
-            <label for="password">Password</label>
-            <input type="password" name="password" id="password" required>
-        </div>
-        <div>
-            <label><input type="checkbox" name="remember"> Remember Me</label>
-        </div>
-        <button type="submit">Login</button>
-    </form>
-    <div class="links">
-        <a href="{{ route('password.request') }}">Forgot Password?</a>
-        <a href="{{ route('register') }}">Register</a>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,34 +1,46 @@
-@extends('layouts.master')
+@extends('user.master')
 
-@section('user-content')
-<div class="auth-form">
-    <h2>Register</h2>
-    <form method="POST" action="{{ route('register') }}">
-        @csrf
-        <div>
-            <label for="username">Username</label>
-            <input type="text" name="username" id="username" value="{{ old('username') }}" required>
+@section('title', 'Register')
+
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header text-center">Register</div>
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('register') }}">
+                            @csrf
+                            <div class="mb-3">
+                                <label for="username" class="form-label">Username</label>
+                                <input type="text" name="username" id="username" class="form-control" value="{{ old('username') }}" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="email" class="form-label">Email</label>
+                                <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="phone" class="form-label">Phone</label>
+                                <input type="text" name="phone" id="phone" class="form-control" value="{{ old('phone') }}" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label">Password</label>
+                                <input type="password" name="password" id="password" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password_confirmation" class="form-label">Confirm Password</label>
+                                <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Register</button>
+                        </form>
+                        <div class="text-center mt-3">
+                            <a href="{{ route('login') }}">Already have an account? Login</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div>
-            <label for="email">Email</label>
-            <input type="email" name="email" id="email" value="{{ old('email') }}" required>
-        </div>
-        <div>
-            <label for="phone">Phone</label>
-            <input type="text" name="phone" id="phone" value="{{ old('phone') }}" required>
-        </div>
-        <div>
-            <label for="password">Password</label>
-            <input type="password" name="password" id="password" required>
-        </div>
-        <div>
-            <label for="password_confirmation">Confirm Password</label>
-            <input type="password" name="password_confirmation" id="password_confirmation" required>
-        </div>
-        <button type="submit">Register</button>
-    </form>
-    <div class="links">
-        <a href="{{ route('login') }}">Already have an account? Login</a>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,24 +1,36 @@
-@extends('layouts.master')
+@extends('user.master')
 
-@section('user-content')
-<div class="auth-form">
-    <h2>Reset Password</h2>
-    <form method="POST" action="{{ route('password.update') }}">
-        @csrf
-        <input type="hidden" name="token" value="{{ $token }}">
-        <div>
-            <label for="email">Email</label>
-            <input type="email" name="email" id="email" value="{{ old('email') }}" required>
+@section('title', 'Reset Password')
+
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header text-center">Reset Password</div>
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('password.update') }}">
+                            @csrf
+                            <input type="hidden" name="token" value="{{ $token }}">
+                            <div class="mb-3">
+                                <label for="email" class="form-label">Email</label>
+                                <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label">New Password</label>
+                                <input type="password" name="password" id="password" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password_confirmation" class="form-label">Confirm Password</label>
+                                <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Reset Password</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div>
-            <label for="password">New Password</label>
-            <input type="password" name="password" id="password" required>
-        </div>
-        <div>
-            <label for="password_confirmation">Confirm Password</label>
-            <input type="password" name="password_confirmation" id="password_confirmation" required>
-        </div>
-        <button type="submit">Reset Password</button>
-    </form>
-</div>
+    </div>
+</section>
 @endsection


### PR DESCRIPTION
## Summary
- Link login, register, reset and forgot password views to `user.master`
- Restyle authentication forms with Bootstrap cards for frontend consistency

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_68b1b3d89adc832dbd25b71ad06a7db9