### PR TITLE
Add dedicated auth layout without topbar

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,28 +1,22 @@
-@extends('user.master')
+@extends('auth.master')
 
 @section('title', 'Forgot Password')
 
 @section('content')
-<section class="py-5">
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-md-6">
-                <div class="card">
-                    <div class="card-header text-center">Forgot Password</div>
-                    <div class="card-body">
-                        <form method="POST" action="{{ route('password.email') }}">
-                            @csrf
-                            <div class="mb-3">
-                                <label for="email" class="form-label">Email Address</label>
-                                <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
-                            </div>
-                            <button type="submit" class="btn btn-primary w-100">Send Reset Link</button>
-                        </form>
-                        <div class="text-center mt-3">
-                            <a href="{{ route('login') }}">Back to Login</a>
-                        </div>
-                    </div>
+<section class="min-vh-100 d-flex justify-content-center align-items-center">
+    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+        <div class="card-header text-center">Forgot Password</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('password.email') }}">
+                @csrf
+                <div class="mb-3">
+                    <label for="email" class="form-label">Email Address</label>
+                    <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
                 </div>
+                <button type="submit" class="btn btn-primary w-100">Send Reset Link</button>
+            </form>
+            <div class="text-center mt-3">
+                <a href="{{ route('login') }}">Back to Login</a>
             </div>
         </div>
     </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,37 +1,31 @@
-@extends('user.master')
+@extends('auth.master')
 
 @section('title', 'Login')
 
 @section('content')
-<section class="py-5">
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-md-6">
-                <div class="card">
-                    <div class="card-header text-center">Login</div>
-                    <div class="card-body">
-                        <form method="POST" action="{{ route('login') }}">
-                            @csrf
-                            <div class="mb-3">
-                                <label for="login" class="form-label">Username / Email / Phone</label>
-                                <input type="text" name="login" id="login" class="form-control" value="{{ old('login') }}" required autofocus>
-                            </div>
-                            <div class="mb-3">
-                                <label for="password" class="form-label">Password</label>
-                                <input type="password" name="password" id="password" class="form-control" required>
-                            </div>
-                            <div class="mb-3 form-check">
-                                <input type="checkbox" name="remember" class="form-check-input" id="remember">
-                                <label class="form-check-label" for="remember">Remember Me</label>
-                            </div>
-                            <button type="submit" class="btn btn-primary w-100">Login</button>
-                        </form>
-                        <div class="text-center mt-3">
-                            <a href="{{ route('password.request') }}" class="d-block">Forgot Password?</a>
-                            <a href="{{ route('register') }}" class="d-block">Register</a>
-                        </div>
-                    </div>
+<section class="min-vh-100 d-flex justify-content-center align-items-center">
+    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+        <div class="card-header text-center">Login</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('login') }}">
+                @csrf
+                <div class="mb-3">
+                    <label for="login" class="form-label">Username / Email / Phone</label>
+                    <input type="text" name="login" id="login" class="form-control" value="{{ old('login') }}" required autofocus>
                 </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">Password</label>
+                    <input type="password" name="password" id="password" class="form-control" required>
+                </div>
+                <div class="mb-3 form-check">
+                    <input type="checkbox" name="remember" class="form-check-input" id="remember">
+                    <label class="form-check-label" for="remember">Remember Me</label>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Login</button>
+            </form>
+            <div class="text-center mt-3">
+                <a href="{{ route('password.request') }}" class="d-block">Forgot Password?</a>
+                <a href="{{ route('register') }}" class="d-block">Register</a>
             </div>
         </div>
     </div>

--- a/resources/views/auth/master.blade.php
+++ b/resources/views/auth/master.blade.php
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- META -->
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', 'Dashboard')</title>
+    <!-- FAVI ICON -->
+    <link rel="icon" type="image/png" href="{{ asset('frontend/assets/images/favi.png') }}" sizes="32x32">
+    <!-- BOOTSTRAP CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/bootstrap/css/bootstrap.min.css') }}">
+    <!-- ALL GOOGLE FONTS -->
+    <link href="https://fonts.googleapis.com/css?family=Droid+Serif:400,400i,700,700i|Bungee+Inline" rel="stylesheet" type="text/css">
+    <!-- FONT AWESOME CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/fonts/linear-fonts.css') }}">
+    <link rel="stylesheet" href="{{ asset('frontend/assets/fonts/font-awesome.css') }}">
+    <!-- OWL CAROSEL CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/owlcarousel/css/owl.carousel.css') }}">
+    <link rel="stylesheet" href="{{ asset('frontend/assets/owlcarousel/css/owl.theme.css') }}">
+    <!-- LIGHTBOX CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/css/lightbox.min.css') }}">
+    <!-- MAGNIFIC CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/css/magnific-popup.css') }}">
+    <!-- ANIMATE CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/css/animate.min.css') }}">
+    <!-- MAIN STYLE CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/css/style.css') }}">
+    <!-- RESPONSIVE CSS -->
+    <link rel="stylesheet" href="{{ asset('frontend/assets/css/responsive.css') }}">
+    <style>
+        .auth-card {
+            background-color: rgba(144, 238, 144, 0.3);
+            border: 1px solid rgba(144, 238, 144, 0.5);
+            backdrop-filter: blur(5px);
+        }
+    </style>
+</head>
+<body>
+    @yield('content')
+
+    <!-- LOCAL COPY OF LATEST JQUERY -->
+    <script type="text/javascript" src="{{ asset('frontend/assets/js/jquery.min.js') }}"></script>
+    <!-- BOOTSTRAP JS -->
+    <script src="{{ asset('frontend/assets/bootstrap/js/bootstrap.min.js') }}"></script>
+    <!-- PROGRESS JS  -->
+    <script src="{{ asset('frontend/assets/js/jquery.appear.js') }}"></script>
+    <!-- OWL CAROUSEL JS  -->
+    <script src="{{ asset('frontend/assets/owlcarousel/js/owl.carousel.min.js') }}"></script>
+    <!-- MIXITUP JS -->
+    <script src="{{ asset('frontend/assets/js/jquery.mixitup.js') }}"></script>
+    <!-- MAGNIFICANT JS -->
+    <script src="{{ asset('frontend/assets/js/jquery.magnific-popup.min.js') }}"></script>
+    <!-- STEALLER JS -->
+    <script src="{{ asset('frontend/assets/js/jquery.stellar.min.js') }}"></script>
+    <!-- YOUTUBE JS -->
+    <script src="{{ asset('frontend/assets/js/jquery.mb.YTPlayer.min.js') }}"></script>
+    <script type="text/javascript">
+        $('.player').mb_YTPlayer();
+    </script>
+    <!-- COUNTER UP JS -->
+    <script src="{{ asset('frontend/assets/js/jquery.waypoints.min.js') }}"></script>
+    <script src="{{ asset('frontend/assets/js/jquery.counterup.min.js') }}"></script>
+    <!-- LIGHTBOX JS -->
+    <script src="{{ asset('frontend/assets/js/lightbox.min.js') }}"></script>
+    <!-- WOW JS -->
+    <script src="{{ asset('frontend/assets/js/wow.min.js') }}"></script>
+    <!-- scripts js -->
+    <script src="{{ asset('frontend/assets/js/scripts.js') }}"></script>
+</body>
+</html>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,44 +1,38 @@
-@extends('user.master')
+@extends('auth.master')
 
 @section('title', 'Register')
 
 @section('content')
-<section class="py-5">
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-md-6">
-                <div class="card">
-                    <div class="card-header text-center">Register</div>
-                    <div class="card-body">
-                        <form method="POST" action="{{ route('register') }}">
-                            @csrf
-                            <div class="mb-3">
-                                <label for="username" class="form-label">Username</label>
-                                <input type="text" name="username" id="username" class="form-control" value="{{ old('username') }}" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="email" class="form-label">Email</label>
-                                <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="phone" class="form-label">Phone</label>
-                                <input type="text" name="phone" id="phone" class="form-control" value="{{ old('phone') }}" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="password" class="form-label">Password</label>
-                                <input type="password" name="password" id="password" class="form-control" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="password_confirmation" class="form-label">Confirm Password</label>
-                                <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
-                            </div>
-                            <button type="submit" class="btn btn-primary w-100">Register</button>
-                        </form>
-                        <div class="text-center mt-3">
-                            <a href="{{ route('login') }}">Already have an account? Login</a>
-                        </div>
-                    </div>
+<section class="min-vh-100 d-flex justify-content-center align-items-center">
+    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+        <div class="card-header text-center">Register</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('register') }}">
+                @csrf
+                <div class="mb-3">
+                    <label for="username" class="form-label">Username</label>
+                    <input type="text" name="username" id="username" class="form-control" value="{{ old('username') }}" required>
                 </div>
+                <div class="mb-3">
+                    <label for="email" class="form-label">Email</label>
+                    <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+                </div>
+                <div class="mb-3">
+                    <label for="phone" class="form-label">Phone</label>
+                    <input type="text" name="phone" id="phone" class="form-control" value="{{ old('phone') }}" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">Password</label>
+                    <input type="password" name="password" id="password" class="form-control" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password_confirmation" class="form-label">Confirm Password</label>
+                    <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Register</button>
+            </form>
+            <div class="text-center mt-3">
+                <a href="{{ route('login') }}">Already have an account? Login</a>
             </div>
         </div>
     </div>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,35 +1,29 @@
-@extends('user.master')
+@extends('auth.master')
 
 @section('title', 'Reset Password')
 
 @section('content')
-<section class="py-5">
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-md-6">
-                <div class="card">
-                    <div class="card-header text-center">Reset Password</div>
-                    <div class="card-body">
-                        <form method="POST" action="{{ route('password.update') }}">
-                            @csrf
-                            <input type="hidden" name="token" value="{{ $token }}">
-                            <div class="mb-3">
-                                <label for="email" class="form-label">Email</label>
-                                <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="password" class="form-label">New Password</label>
-                                <input type="password" name="password" id="password" class="form-control" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="password_confirmation" class="form-label">Confirm Password</label>
-                                <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
-                            </div>
-                            <button type="submit" class="btn btn-primary w-100">Reset Password</button>
-                        </form>
-                    </div>
+<section class="min-vh-100 d-flex justify-content-center align-items-center">
+    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+        <div class="card-header text-center">Reset Password</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('password.update') }}">
+                @csrf
+                <input type="hidden" name="token" value="{{ $token }}">
+                <div class="mb-3">
+                    <label for="email" class="form-label">Email</label>
+                    <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
                 </div>
-            </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">New Password</label>
+                    <input type="password" name="password" id="password" class="form-control" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password_confirmation" class="form-label">Confirm Password</label>
+                    <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Reset Password</button>
+            </form>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- create `auth.master` layout without the user topbar and add translucent green card styling
- center auth forms in transparent green cards using the new layout

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68b1b9e8ea04832d9693d95fcb4326af