### PR TITLE
Improve auth card design

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 
-<section class="min-vh-100 d-flex justify-content-center align-items-center">
+<section class="auth-wrapper">
     <div class="card auth-card" style="width: 100%; max-width: 400px;">
         <div class="card-header text-center">Forgot Password</div>
         <div class="card-body">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 
-<section class="min-vh-100 d-flex justify-content-center align-items-center">
+<section class="auth-wrapper">
     <div class="card auth-card" style="width: 100%; max-width: 400px;">
         <div class="card-header text-center">Login</div>
         <div class="card-body">

--- a/resources/views/auth/master.blade.php
+++ b/resources/views/auth/master.blade.php
@@ -29,9 +29,18 @@
     <!-- RESPONSIVE CSS -->
     <link rel="stylesheet" href="{{ asset('frontend/assets/css/responsive.css') }}">
     <style>
+        .auth-wrapper {
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
         .auth-card {
-            background-color: rgba(144, 238, 144, 0.3);
-            border: 1px solid rgba(144, 238, 144, 0.5);
+            background-color: rgba(255, 255, 255, 0.75);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 15px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
             backdrop-filter: blur(5px);
         }
     </style>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 
-<section class="min-vh-100 d-flex justify-content-center align-items-center">
+<section class="auth-wrapper">
     <div class="card auth-card" style="width: 100%; max-width: 400px;">
         <div class="card-header text-center">Register</div>
         <div class="card-body">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 
-<section class="min-vh-100 d-flex justify-content-center align-items-center">
+<section class="auth-wrapper">
     <div class="card auth-card" style="width: 100%; max-width: 400px;">
         <div class="card-header text-center">Reset Password</div>
         <div class="card-body">


### PR DESCRIPTION
## Summary
- center all auth cards with a reusable `auth-wrapper`
- restyle auth cards with rounded corners, shadow and translucent background

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68b1bde8cde4832d8a2034c351ca049a