### PR TITLE
style: enhance auth UI styling

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 
 <section class="auth-wrapper">
-    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+    <div class="card auth-card">
         <div class="card-header text-center">Forgot Password</div>
         <div class="card-body">
             <form method="POST" action="{{ route('password.email') }}">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 
 <section class="auth-wrapper">
-    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+    <div class="card auth-card">
         <div class="card-header text-center">Login</div>
         <div class="card-body">
             <form method="POST" action="{{ route('login') }}">

--- a/resources/views/auth/master.blade.php
+++ b/resources/views/auth/master.blade.php
@@ -34,14 +34,25 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+            background-size: cover;
         }
 
         .auth-card {
+            width: 100%;
+            max-width: 500px;
             background-color: rgba(255, 255, 255, 0.75);
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            border-radius: 15px;
+            border: 2px solid #FFD700;
+            border-radius: 20px;
             box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
             backdrop-filter: blur(5px);
+        }
+
+        .auth-card .form-control {
+            border: 1px solid purple;
+            border-radius: 8px;
+            font-size: 0.9rem;
+            padding: 8px 12px;
         }
     </style>
 </head>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 
 <section class="auth-wrapper">
-    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+    <div class="card auth-card">
         <div class="card-header text-center">Register</div>
         <div class="card-body">
             <form method="POST" action="{{ route('register') }}">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 
 <section class="auth-wrapper">
-    <div class="card auth-card" style="width: 100%; max-width: 400px;">
+    <div class="card auth-card">
         <div class="card-header text-center">Reset Password</div>
         <div class="card-body">
             <form method="POST" action="{{ route('password.update') }}">

--- a/resources/views/user/topbar.blade.php
+++ b/resources/views/user/topbar.blade.php
@@ -32,6 +32,17 @@
                         <li><a href="#main-content">Blog</a></li>
                         <li><a href="{{ asset('frontend/about.html') }}">About</a></li>
                         <li><a href="{{ asset('frontend/contact.html') }}">Contact</a></li>
+                        @auth
+                            <li>
+                                <a href="{{ route('logout') }}" class="slide-btn"
+                                    onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                    Logout
+                                </a>
+                                <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                                    @csrf
+                                </form>
+                            </li>
+                        @endauth
                     </ul>
                 </div>
                 <!-- / END CONTENT FOR TOGGLING -->


### PR DESCRIPTION
## Summary
- add dark multicolor background and golden card styling to auth pages
- remove inline auth card widths and add purple-bordered inputs
- add themed logout button on user dashboard

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68b1c089fc70832daafa3b75d72325be