### PR TITLE
Define login rate limiter

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('login', function (Request $request) {
+            $login = (string) $request->input('login');
+
+            return [
+                Limit::perMinute(5)->by($login.$request->ip()),
+            ];
+        });
     }
 }


### PR DESCRIPTION
## Summary
- define `login` rate limiter to throttle repeated login attempts

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68b1c4d08fd4832d837f574ec278e3a3