### PR TITLE
Add registration email and OTP-based password reset

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -8,6 +8,8 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\RegistrationSuccessMail;
 
 class AuthController extends Controller
 {
@@ -28,6 +30,8 @@ class AuthController extends Controller
         $data['password'] = Hash::make($data['password']);
 
         $user = User::create($data);
+
+        Mail::to($user->email)->send(new RegistrationSuccessMail());
 
         Auth::login($user);
         $request->session()->regenerate();

--- a/app/Http/Controllers/PasswordResetController.php
+++ b/app/Http/Controllers/PasswordResetController.php
@@ -4,15 +4,15 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ForgotPasswordRequest;
 use App\Http\Requests\ResetPasswordRequest;
-use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Facades\Auth;
+use App\Mail\PasswordResetOtpMail;
+use App\Models\User;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Mail;
 
 class PasswordResetController extends Controller
 {
     /**
-     * Display the form to request a password reset link.
+     * Display the form to request a password reset OTP.
      */
     public function showForgot()
     {
@@ -20,47 +20,52 @@ class PasswordResetController extends Controller
     }
 
     /**
-     * Handle sending the password reset link.
+     * Send an OTP to the user's email address.
      */
-    public function sendResetLink(ForgotPasswordRequest $request)
+    public function sendOtp(ForgotPasswordRequest $request)
     {
-        $status = Password::sendResetLink(
-            $request->only('email')
-        );
+        $user = User::where('email', $request->email)->first();
 
-        return $status === Password::RESET_LINK_SENT
-            ? back()->with('status', __($status))
-            : back()->withErrors(['email' => __($status)]);
+        $otp = (string) rand(100000, 999999);
+        $user->forceFill([
+            'otp' => $otp,
+            'otp_expires_at' => now()->addMinutes(10),
+        ])->save();
+
+        Mail::to($user->email)->send(new PasswordResetOtpMail($otp));
+
+        session(['otp_email' => $user->email]);
+
+        return redirect()->route('password.reset');
     }
 
     /**
-     * Show the reset password form.
+     * Show the form to reset the password using OTP.
      */
-    public function showReset(string $token)
+    public function showReset()
     {
-        return view('auth.reset-password', ['token' => $token]);
+        return view('auth.reset-password');
     }
 
     /**
-     * Handle resetting the password.
+     * Reset the user's password after verifying the OTP.
      */
     public function resetPassword(ResetPasswordRequest $request)
     {
-        $status = Password::reset(
-            $request->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user, $password) {
-                $user->forceFill([
-                    'password' => Hash::make($password),
-                ])->save();
+        $user = User::where('email', $request->email)->first();
 
-                $user->setRememberToken(Str::random(60));
+        if (! $user || $user->otp !== $request->otp || now()->greaterThan($user->otp_expires_at)) {
+            return back()->withErrors(['otp' => 'Invalid or expired OTP.']);
+        }
 
-                Auth::login($user);
-            }
-        );
+        $user->forceFill([
+            'password' => Hash::make($request->password),
+            'otp' => null,
+            'otp_expires_at' => null,
+        ])->save();
 
-        return $status === Password::PASSWORD_RESET
-            ? redirect()->route('dashboard')->with('status', __($status))
-            : back()->withErrors(['email' => [__($status)]]);
+        session()->forget('otp_email');
+
+        return redirect()->route('login')->with('status', 'Password reset successful.');
     }
 }

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -14,8 +14,8 @@ class ResetPasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'token' => ['required', 'string'],
             'email' => ['required', 'email', 'exists:users,email'],
+            'otp' => ['required', 'digits:6'],
             'password' => ['required', 'string', 'confirmed', 'min:8', 'regex:/^(?=.*[A-Za-z])(?=.*\d).+$/'],
         ];
     }

--- a/app/Mail/PasswordResetOtpMail.php
+++ b/app/Mail/PasswordResetOtpMail.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetOtpMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public string $otp;
+
+    public function __construct(string $otp)
+    {
+        $this->otp = $otp;
+    }
+
+    public function build()
+    {
+        return $this->subject('Your Password Reset OTP')
+                    ->view('emails.password-reset-otp')
+                    ->with(['otp' => $this->otp]);
+    }
+}

--- a/app/Mail/RegistrationSuccessMail.php
+++ b/app/Mail/RegistrationSuccessMail.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class RegistrationSuccessMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function build()
+    {
+        return $this->subject('Registration Successful')
+                    ->view('emails.registration-success');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,8 @@ class User extends Authenticatable
         'email',
         'phone',
         'password',
+        'otp',
+        'otp_expires_at',
     ];
 
     /**
@@ -32,6 +34,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'otp',
     ];
 
     /**
@@ -44,6 +47,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'otp_expires_at' => 'datetime',
         ];
     }
 }

--- a/database/migrations/2025_08_28_000003_add_otp_fields_to_users_table.php
+++ b/database/migrations/2025_08_28_000003_add_otp_fields_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('otp', 6)->nullable();
+            $table->timestamp('otp_expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['otp', 'otp_expires_at']);
+        });
+    }
+};

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -14,7 +14,7 @@
                     <label for="email" class="form-label">Email Address</label>
                     <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
                 </div>
-                <button type="submit" class="btn btn-primary w-100">Send Reset Link</button>
+                <button type="submit" class="btn btn-primary w-100">Send OTP</button>
             </form>
             <div class="text-center mt-3">
                 <a href="{{ route('login') }}">Back to Login</a>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -10,10 +10,10 @@
         <div class="card-body">
             <form method="POST" action="{{ route('password.update') }}">
                 @csrf
-                <input type="hidden" name="token" value="{{ $token }}">
+                <input type="hidden" name="email" value="{{ old('email', session('otp_email')) }}">
                 <div class="mb-3">
-                    <label for="email" class="form-label">Email</label>
-                    <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+                    <label for="otp" class="form-label">OTP</label>
+                    <input type="text" name="otp" id="otp" class="form-control" required placeholder="123456">
                 </div>
                 <div class="mb-3">
                     <label for="password" class="form-label">New Password</label>

--- a/resources/views/emails/password-reset-otp.blade.php
+++ b/resources/views/emails/password-reset-otp.blade.php
@@ -1,0 +1,2 @@
+<p>Your OTP for resetting password is: {{ $otp }}</p>
+<p>This code will expire in 10 minutes.</p>

--- a/resources/views/emails/registration-success.blade.php
+++ b/resources/views/emails/registration-success.blade.php
@@ -1,0 +1,1 @@
+<p>Your registration was successful.</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,8 +18,8 @@ Route::middleware('guest')->group(function () {
     Route::get('/login', [AuthController::class, 'showLogin'])->name('login');
     Route::post('/login', [AuthController::class, 'login'])->middleware('throttle:login');
     Route::get('/password/forgot', [PasswordResetController::class, 'showForgot'])->name('password.request');
-    Route::post('/password/email', [PasswordResetController::class, 'sendResetLink'])->name('password.email');
-    Route::get('/password/reset/{token}', [PasswordResetController::class, 'showReset'])->name('password.reset');
+    Route::post('/password/otp', [PasswordResetController::class, 'sendOtp'])->name('password.email');
+    Route::get('/password/reset', [PasswordResetController::class, 'showReset'])->name('password.reset');
     Route::post('/password/reset', [PasswordResetController::class, 'resetPassword'])->name('password.update');
 });
 


### PR DESCRIPTION
## Summary
- send confirmation email after user registration
- implement OTP-based password reset flow with email delivery
- track OTP data on users table and expose new reset views

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68b1c6648348832d949d33c4ea8fd464