### PR TITLE
Add admin notifications and chat system with SweetAlert

### DIFF
--- a/app/Http/Controllers/Admin/MessageController.php
+++ b/app/Http/Controllers/Admin/MessageController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class MessageController extends Controller
+{
+    public function index()
+    {
+        $users = Message::with('user')
+            ->select('user_id')
+            ->groupBy('user_id')
+            ->get()
+            ->pluck('user');
+
+        return view('admin.messages.index', ['users' => $users]);
+    }
+
+    public function show(User $user)
+    {
+        $messages = Message::where('user_id', $user->id)
+            ->orderBy('created_at')
+            ->get();
+
+        Message::where('user_id', $user->id)
+            ->where('sender', 'user')
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return view('admin.messages.show', compact('user', 'messages'));
+    }
+
+    public function store(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'message' => ['required', 'string'],
+        ]);
+
+        Message::create([
+            'user_id' => $user->id,
+            'sender' => 'admin',
+            'message' => $data['message'],
+        ]);
+
+        return back()->with('status', 'Reply sent.');
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Message;
+use Illuminate\Http\Request;
+
+class ChatController extends Controller
+{
+    public function index(Request $request)
+    {
+        $messages = Message::where('user_id', $request->user()->id)
+            ->orderBy('created_at')
+            ->get();
+
+        Message::where('user_id', $request->user()->id)
+            ->where('sender', 'admin')
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return view('user.chat', compact('messages'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'message' => ['required', 'string'],
+        ]);
+
+        Message::create([
+            'user_id' => $request->user()->id,
+            'sender' => 'user',
+            'message' => $data['message'],
+        ]);
+
+        return back()->with('status', 'Message sent.');
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'sender',
+        'message',
+        'read_at',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_09_01_162821_create_messages_table.php
+++ b/database/migrations/2025_09_01_162821_create_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->enum('sender', ['user', 'admin']);
+            $table->text('message');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/resources/views/admin/deposits/pending.blade.php
+++ b/resources/views/admin/deposits/pending.blade.php
@@ -20,7 +20,7 @@
         </thead>
         <tbody>
             @foreach($deposits as $deposit)
-            <tr>
+            <tr id="deposit-{{ $deposit->id }}">
                 <td>{{ $deposit->user->username }}</td>
                 <td>{{ $deposit->amount }}</td>
                 <td>{{ $deposit->currency }}</td>

--- a/resources/views/admin/layouts/master.blade.php
+++ b/resources/views/admin/layouts/master.blade.php
@@ -264,83 +264,23 @@
                 <div class="mode"><i class="fa fa-moon-o"></i></div>
               </li>
               <li class="onhover-dropdown">
-                <div class="notification-box"><i data-feather="bell"></i></div>
+                @php($pendingDeposits = \App\Models\Deposit::where('status','pending')->latest()->take(5)->get())
+                <div class="notification-box"><i data-feather="bell"></i><span class="badge rounded-pill bg-primary">{{ $pendingDeposits->count() }}</span></div>
                 <ul class="notification-dropdown onhover-show-div">
-                  <li><i data-feather="bell">            </i>
-                    <h6 class="f-18 mb-0">Notitications</h6>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-center">
-                      <div class="flex-shrink-0"><i data-feather="truck"></i></div>
-                      <div class="flex-grow-1">
-                        <p><a href="order-history.html">Delivery processing </a><span class="pull-right">6 hr</span></p>
-                      </div>
-                    </div>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-center">
-                      <div class="flex-shrink-0"><i data-feather="shopping-cart"></i></div>
-                      <div class="flex-grow-1">
-                        <p><a href="cart.html">Order Complete</a><span class="pull-right">3 hr</span></p>
-                      </div>
-                    </div>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-center">
-                      <div class="flex-shrink-0"><i data-feather="file-text"></i></div>
-                      <div class="flex-grow-1">
-                        <p><a href="invoice-template.html">Tickets Generated</a><span class="pull-right">1 hr</span></p>
-                      </div>
-                    </div>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-center">
-                      <div class="flex-shrink-0"><i data-feather="send"></i></div>
-                      <div class="flex-grow-1">
-                        <p><a href="email_inbox.html">Delivery Complete</a><span class="pull-right">45 min</span></p>
-                      </div>
-                    </div>
-                  </li>
-                  <li><a class="btn btn-primary" href="javascript:void(0)">Check all notification</a></li>
+                  <li><i data-feather="bell"></i><h6 class="f-18 mb-0">Deposits</h6></li>
+                  @foreach($pendingDeposits as $deposit)
+                    <li><a href="{{ route('admin.deposits.pending') }}#deposit-{{ $deposit->id }}">{{ $deposit->user->username }} - {{ $deposit->amount }}</a></li>
+                  @endforeach
                 </ul>
               </li>
               <li class="onhover-dropdown">
-                <div class="message"><i data-feather="message-square"></i></div>
-                <ul class="message-dropdown onhover-show-div">
-                  <li><i data-feather="message-square">            </i>
-                    <h6 class="f-18 mb-0">Messages</h6>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-start">
-                      <div class="message-img bg-light-primary"><img src="{{ asset('backend/assets/css/responsive.css') }}" alt=""></div>
-                      <div class="flex-grow-1">
-                        <h5 class="mb-1"><a href="email_inbox.html">Emay Walter</a></h5>
-                        <p>Do you want to go see movie?</p>
-                      </div>
-                      <div class="notification-right"><i data-feather="x"></i></div>
-                    </div>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-start">
-                      <div class="message-img bg-light-primary"><img src="{{ asset('backend/assets/images/user/6.jpg') }}" alt=""></div>
-                      <div class="flex-grow-1">
-                        <h5 class="mb-1"><a href="email_inbox.html">Jason Borne</a></h5>
-                        <p>Thank you for rating us.</p>
-                      </div>
-                      <div class="notification-right"><i data-feather="x"></i></div>
-                    </div>
-                  </li>
-                  <li>
-                    <div class="d-flex align-items-start">
-                      <div class="message-img bg-light-primary"><img src="{{ asset('backend/assets/images/user/10.jpg') }}" alt=""></div>
-                      <div class="flex-grow-1">
-                        <h5 class="mb-1"><a href="email_inbox.html">Sarah Loren</a></h5>
-                        <p>What`s the project report update?</p>
-                      </div>
-                      <div class="notification-right"><i data-feather="x"></i></div>
-                    </div>
-                  </li>
-                  <li><a class="btn btn-primary" href="email_inbox.html">Check Messages</a></li>
+                @php($unread = \App\Models\Message::where('sender','user')->whereNull('read_at')->latest()->get())
+                <div class="notification-box"><i data-feather="message-square"></i><span class="badge rounded-pill bg-primary">{{ $unread->count() }}</span></div>
+                <ul class="notification-dropdown onhover-show-div">
+                  <li><i data-feather="message-square"></i><h6 class="f-18 mb-0">Messages</h6></li>
+                  @foreach($unread->groupBy('user_id') as $userId => $messages)
+                    <li><a href="{{ route('admin.messages.show', $userId) }}">{{ $messages->first()->user->username }} ({{ $messages->count() }})</a></li>
+                  @endforeach
                 </ul>
               </li>
               <li class="maximize"><a href="#!" onclick="javascript:toggleFullScreen()"><i data-feather="maximize-2"></i></a></li>
@@ -447,5 +387,14 @@
     <script src="{{ asset('backend/assets/js/theme-customizer/customizer.js') }}"></script>
     <!-- login js-->
     @stack('scripts')
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    @if(session('status'))
+    <script>
+        Swal.fire({
+            icon: 'success',
+            text: '{{ session('status') }}'
+        });
+    </script>
+    @endif
   </body>
 </html>

--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -1,0 +1,11 @@
+@extends('admin.layouts.master')
+@section('admin-content')
+<div class="container mt-4">
+    <h2 class="mb-4">User Messages</h2>
+    <ul>
+        @foreach($users as $user)
+            <li><a href="{{ route('admin.messages.show', $user) }}">{{ $user->username }}</a></li>
+        @endforeach
+    </ul>
+</div>
+@endsection

--- a/resources/views/admin/messages/show.blade.php
+++ b/resources/views/admin/messages/show.blade.php
@@ -1,0 +1,21 @@
+@extends('admin.layouts.master')
+@section('admin-content')
+<div class="container mt-4">
+    <h2 class="mb-4">Chat with {{ $user->username }}</h2>
+    <div class="mb-3" style="max-height:300px; overflow-y:auto;">
+        @foreach($messages as $message)
+            <div class="mb-2">
+                <strong>{{ $message->sender === 'admin' ? 'You' : $user->username }}:</strong>
+                {{ $message->message }}
+            </div>
+        @endforeach
+    </div>
+    <form method="POST" action="{{ route('admin.messages.store', $user) }}">
+        @csrf
+        <div class="input-group">
+            <input type="text" name="message" class="form-control" placeholder="Type your reply">
+            <button class="btn btn-primary" type="submit">Send</button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/user/chat.blade.php
+++ b/resources/views/user/chat.blade.php
@@ -1,0 +1,22 @@
+@extends('user.master')
+
+@section('user-content')
+<div class="container mt-5">
+    <h2 class="mb-4">Chat with Admin</h2>
+    <div class="mb-3" style="max-height:300px; overflow-y:auto;">
+        @foreach($messages as $message)
+            <div class="mb-2">
+                <strong>{{ $message->sender === 'user' ? 'You' : 'Admin' }}:</strong>
+                {{ $message->message }}
+            </div>
+        @endforeach
+    </div>
+    <form method="POST" action="{{ route('chat.store') }}">
+        @csrf
+        <div class="input-group">
+            <input type="text" name="message" class="form-control" placeholder="Type your message">
+            <button class="btn btn-primary" type="submit">Send</button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/user/master.blade.php
+++ b/resources/views/user/master.blade.php
@@ -75,5 +75,14 @@
     <script src="{{ asset('frontend/assets/js/wow.min.js') }}"></script>
     <!-- scripts js -->
     <script src="{{ asset('frontend/assets/js/scripts.js') }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    @if(session('status'))
+        <script>
+            Swal.fire({
+                icon: 'success',
+                text: '{{ session('status') }}'
+            });
+        </script>
+    @endif
 </body>
 </html>

--- a/resources/views/user/topbar.blade.php
+++ b/resources/views/user/topbar.blade.php
@@ -30,6 +30,7 @@
                             <li><a href="#">{{ auth()->user()->username }}</a></li>
                             <li><a href="#">Balance: {{ auth()->user()->balance }}</a></li>
                             <li><a href="{{ route('deposit.index') }}">Deposit</a></li>
+                            <li><a href="{{ route('chat.index') }}">Chat</a></li>
                             <li>
                                 <a href="{{ route('logout') }}" class="slide-btn"
                                     onclick="event.preventDefault(); document.getElementById('logout-form').submit();">

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Auth\AdminAuthController;
 use App\Http\Controllers\DepositController;
 use App\Http\Controllers\Admin\DepositController as AdminDepositController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Controllers\ChatController;
+use App\Http\Controllers\Admin\MessageController as AdminMessageController;
 
 // Route::get('/', function () {
 //     return auth()->check()
@@ -35,6 +37,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/deposit/create', [DepositController::class, 'create'])->name('deposit.create');
     Route::post('/deposit', [DepositController::class, 'store'])->name('deposit.store');
     Route::get('/deposit/history', [DepositController::class, 'history'])->name('deposit.history');
+
+    Route::get('/chat', [ChatController::class, 'index'])->name('chat.index');
+    Route::post('/chat', [ChatController::class, 'store'])->name('chat.store');
 
     Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 });
@@ -65,5 +70,9 @@ Route::prefix('admin')->group(function () {
         Route::get('/users', [AdminUserController::class, 'index'])->name('admin.users.index');
         Route::get('/users/{user}/edit', [AdminUserController::class, 'edit'])->name('admin.users.edit');
         Route::put('/users/{user}', [AdminUserController::class, 'update'])->name('admin.users.update');
+
+        Route::get('/messages', [AdminMessageController::class, 'index'])->name('admin.messages.index');
+        Route::get('/messages/{user}', [AdminMessageController::class, 'show'])->name('admin.messages.show');
+        Route::post('/messages/{user}', [AdminMessageController::class, 'store'])->name('admin.messages.store');
     });
 });


### PR DESCRIPTION
## Summary
- track user-admin conversations through new messages table and models
- notify admins of pending deposits and unread chats in the top bar
- show SweetAlert popups for status messages across user and admin sections

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68b5c94de69c832da2d1d6f9630ba3b2