### PR TITLE
Revamp auth and user UI with modern styling

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -21,3 +21,47 @@
     background: linear-gradient(45deg, #f06595, #ff6b6b);
     transform: translateY(-2px);
 }
+
+/* Messenger like chat bubbles */
+.chat-window {
+    max-height: 300px;
+    overflow-y: auto;
+    padding: 10px;
+}
+
+.chat-bubble {
+    padding: 8px 12px;
+    border-radius: 15px;
+    max-width: 70%;
+    margin-bottom: 8px;
+}
+
+.chat-bubble.user {
+    background: #0d6efd;
+    color: #fff;
+    margin-left: auto;
+    border-bottom-right-radius: 0;
+}
+
+.chat-bubble.admin {
+    background: #f1f0f0;
+    margin-right: auto;
+    border-bottom-left-radius: 0;
+}
+
+/* Grey cards with yellow headers */
+.card-grey {
+    background-color: #343a40;
+    color: #fff;
+    border-radius: 20px;
+    border: none;
+}
+
+.card-grey .card-header {
+    background-color: #343a40;
+    color: #FFD700;
+    font-weight: bold;
+    border-bottom: 2px solid #FFD700;
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+}

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,5 +1,17 @@
 @extends('admin.layouts.master')
 @section('admin-content')
+<style>
+body {
+    background: radial-gradient(circle at 20% 20%, #0f0c29, #302b63, #24243e);
+    background-size: 400% 400%;
+    animation: adminGalaxy 15s ease infinite;
+}
+@keyframes adminGalaxy {
+    0% {background-position: 0% 50%;}
+    50% {background-position: 100% 50%;}
+    100% {background-position: 0% 50%;}
+}
+</style>
 
     <!-- Loader starts-->
     <div class="loader-wrapper">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -12,14 +12,20 @@
                 @csrf
                 <div class="mb-3">
                     <label for="login" class="form-label">Username / Email / Phone</label>
-                    <input type="text" name="login" id="login" class="form-control" value="{{ old('login') }}" required autofocus>
+                    <input type="text" name="login" id="login" class="form-control @error('login') is-invalid @enderror" value="{{ old('login') }}" required autofocus>
+                    @error('login')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
                 <div class="mb-3">
                     <label for="password" class="form-label">Password</label>
-                    <input type="password" name="password" id="password" class="form-control" required>
+                    <input type="password" name="password" id="password" class="form-control @error('password') is-invalid @enderror" required>
+                    @error('password')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
                 <div class="mb-3 form-check">
-                    <input type="checkbox" name="remember" class="form-check-input" id="remember">
+                    <input type="checkbox" name="remember" class="form-check-input" id="remember" {{ old('remember') ? 'checked' : '' }}>
                     <label class="form-check-label" for="remember">Remember Me</label>
                 </div>
                 <button type="submit" class="btn btn-primary w-100">Login</button>

--- a/resources/views/auth/master.blade.php
+++ b/resources/views/auth/master.blade.php
@@ -34,23 +34,44 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
-            background-size: 400% 400%;
-            animation: gradientBG 15s ease infinite;
+            background: radial-gradient(circle at 20% 20%, #0f0c29, #302b63, #24243e);
+            overflow: hidden;
+        }
+
+        .auth-wrapper::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: url('https://www.transparenttextures.com/patterns/stardust.png');
+            animation: stars 60s linear infinite;
+            opacity: .5;
         }
 
         .auth-card {
             width: 100%;
             max-width: 500px;
-            background-color: rgba(255, 255, 255, 0.75);
+            background-color: rgba(52, 58, 64, 0.85);
             border: 2px solid #FFD700;
             border-radius: 20px;
-            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
             backdrop-filter: blur(5px);
+            position: relative;
+            z-index: 1;
+        }
+
+        .auth-card .card-header {
+            background-color: #343a40;
+            color: #FFD700;
+            border-top-left-radius: 20px;
+            border-top-right-radius: 20px;
+            font-weight: bold;
         }
 
         .auth-card .form-control {
-            border: 1px solid purple;
+            border: 1px solid #6c757d;
             border-radius: 8px;
             font-size: 100%;
             font-weight: bold;
@@ -58,10 +79,13 @@
             padding: 12px 16px;
         }
 
-        @keyframes gradientBG {
-            0% {background-position: 0% 50%;}
-            50% {background-position: 100% 50%;}
-            100% {background-position: 0% 50%;}
+        .invalid-feedback {
+            display: block;
+        }
+
+        @keyframes stars {
+            from {transform: translateY(0);}
+            to {transform: translateY(-2000px);}
         }
     </style>
 </head>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -12,19 +12,31 @@
                 @csrf
                 <div class="mb-3">
                     <label for="username" class="form-label">Username</label>
-                    <input type="text" name="username" id="username" class="form-control" value="{{ old('username') }}" required>
+                    <input type="text" name="username" id="username" class="form-control @error('username') is-invalid @enderror" value="{{ old('username') }}" required>
+                    @error('username')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
                 <div class="mb-3">
                     <label for="email" class="form-label">Email</label>
-                    <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+                    <input type="email" name="email" id="email" class="form-control @error('email') is-invalid @enderror" value="{{ old('email') }}" required>
+                    @error('email')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
                 <div class="mb-3">
                     <label for="phone" class="form-label">Phone</label>
-                    <input type="text" name="phone" id="phone" class="form-control" value="{{ old('phone') }}" required>
+                    <input type="text" name="phone" id="phone" class="form-control @error('phone') is-invalid @enderror" value="{{ old('phone') }}" required>
+                    @error('phone')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
                 <div class="mb-3">
                     <label for="password" class="form-label">Password</label>
-                    <input type="password" name="password" id="password" class="form-control" required>
+                    <input type="password" name="password" id="password" class="form-control @error('password') is-invalid @enderror" required>
+                    @error('password')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
                 <div class="mb-3">
                     <label for="password_confirmation" class="form-label">Confirm Password</label>

--- a/resources/views/user/chat.blade.php
+++ b/resources/views/user/chat.blade.php
@@ -3,11 +3,12 @@
 @section('user-content')
 <div class="container mt-5">
     <h2 class="mb-4">Chat with Admin</h2>
-    <div class="mb-3" style="max-height:300px; overflow-y:auto;">
+    <div class="chat-window mb-3">
         @foreach($messages as $message)
-            <div class="mb-2">
-                <strong>{{ $message->sender === 'user' ? 'You' : 'Admin' }}:</strong>
-                {{ $message->message }}
+            <div class="d-flex {{ $message->sender === 'user' ? 'justify-content-end' : 'justify-content-start' }}">
+                <div class="chat-bubble {{ $message->sender === 'user' ? 'user' : 'admin' }}">
+                    {{ $message->message }}
+                </div>
             </div>
         @endforeach
     </div>

--- a/resources/views/user/deposit-history.blade.php
+++ b/resources/views/user/deposit-history.blade.php
@@ -4,9 +4,9 @@
 <div class="container mt-5">
     <div class="row justify-content-center">
         <div class="col-md-10">
-            <div class="card shadow-lg border-0">
+            <div class="card card-grey shadow-lg">
+                <div class="card-header text-center">Deposit History</div>
                 <div class="card-body">
-                    <h2 class="mb-4 text-center">Deposit History</h2>
                     @if(session('status'))
                         <div class="alert alert-success">{{ session('status') }}</div>
                     @endif

--- a/resources/views/user/deposit.blade.php
+++ b/resources/views/user/deposit.blade.php
@@ -4,9 +4,9 @@
 <div class="container mt-5">
     <div class="row justify-content-center">
         <div class="col-md-6">
-            <div class="card shadow-lg border-0">
+            <div class="card card-grey shadow-lg">
+                <div class="card-header text-center">Deposit</div>
                 <div class="card-body p-4">
-                    <h2 class="mb-4 text-center">Deposit</h2>
                     <form method="POST" action="{{ route('deposit.store') }}">
                         @csrf
                         <div class="mb-3">

--- a/resources/views/user/topbar.blade.php
+++ b/resources/views/user/topbar.blade.php
@@ -28,7 +28,7 @@
                         <li class="active"><a href="{{ route('dashboard') }}">Home</a></li>
                         @auth
                             <li><a href="#">{{ auth()->user()->username }}</a></li>
-                            <li><a href="#">Balance: {{ auth()->user()->balance }}</a></li>
+                            <li><a href="#">Balance: {{ rtrim(rtrim(number_format(auth()->user()->balance, 2, '.', ''), '0'), '.') }}</a></li>
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                     Deposit <span class="caret"></span>


### PR DESCRIPTION
## Summary
- Add galaxy themed backgrounds and stylish grey cards to auth pages
- Show validation errors and remember-me support on login/register
- Style chat, deposit forms, balance display, and history cards

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68b6b53ec1a4832d998b7d71fa766d0e