### PR TITLE
Add log viewer route and password visibility toggle

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -33,14 +33,20 @@
                 </div>
                 <div class="mb-3">
                     <label for="password" class="form-label">Password</label>
-                    <input type="password" name="password" id="password" class="form-control @error('password') is-invalid @enderror" required>
+                    <div class="input-group">
+                        <input type="password" name="password" id="password" class="form-control @error('password') is-invalid @enderror" required>
+                        <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#password">Show</button>
+                    </div>
                     @error('password')
                         <div class="invalid-feedback">{{ $message }}</div>
                     @enderror
                 </div>
                 <div class="mb-3">
                     <label for="password_confirmation" class="form-label">Confirm Password</label>
-                    <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
+                    <div class="input-group">
+                        <input type="password" name="password_confirmation" id="password_confirmation" class="form-control" required>
+                        <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#password_confirmation">Show</button>
+                    </div>
                 </div>
                 <button type="submit" class="btn btn-primary btn-lg w-100 text-center ">Register</button>
             </form>
@@ -50,4 +56,18 @@
         </div>
     </div>
 </section>
+<script>
+    document.querySelectorAll('.toggle-password').forEach(function (button) {
+        button.addEventListener('click', function () {
+            const input = document.querySelector(this.dataset.target);
+            if (input.type === 'password') {
+                input.type = 'text';
+                this.textContent = 'Hide';
+            } else {
+                input.type = 'password';
+                this.textContent = 'Show';
+            }
+        });
+    });
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,20 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\File;
 
 Route::view('/', 'home');
 
 Route::prefix('user')->group(__DIR__.'/user.php');
 Route::prefix('admin')->group(__DIR__.'/admin.php');
+
+Route::get('/logs', function () {
+    $path = storage_path('logs/laravel.log');
+
+    if (!File::exists($path)) {
+        abort(404, 'Log file not found.');
+    }
+
+    return response('<pre>'.e(File::get($path)).'</pre>');
+})->name('logs');
 


### PR DESCRIPTION
## Summary
- expose `/logs` route to display current application error log
- add show/hide buttons for password fields on registration form

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bee4356df0832d8e06584c093ccbdb